### PR TITLE
fn benchmarks

### DIFF
--- a/anafind/benchmarks_test.go
+++ b/anafind/benchmarks_test.go
@@ -63,6 +63,17 @@ func BenchmarkAutomi(b *testing.B) {
 	checkCorrectness(b, out)
 }
 
+func BenchmarkFn(b *testing.B) {
+	input := TextAsSlice()
+	var out map[string]map[string]struct{}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		out = Fn(input)
+	}
+	b.StopTimer()
+	checkCorrectness(b, out)
+}
+
 func checkCorrectness(b *testing.B, in map[string]map[string]struct{}) {
 	assert.Equal(b, map[string]struct{}{"neither": {}, "therein": {}}, in["eehinrt"])
 	assert.Equal(b, map[string]struct{}{"there": {}, "three": {}}, in["eehrt"])

--- a/anafind/fn.go
+++ b/anafind/fn.go
@@ -1,0 +1,14 @@
+package anafind
+
+import (
+	"strings"
+
+	"github.com/kamstrup/fn"
+)
+
+func Fn(words []string) map[string]map[string]struct{} {
+	nzWords := fn.ArrayOf(words).Where(MoreThanOneChar)
+	lower := fn.MapOf(nzWords, strings.ToLower)
+	singleWords := fn.MapOf(lower, SingleWordToMap)
+	return fn.Into(Anagrams{}, Accumulate, singleWords)
+}

--- a/anafind/fn.go
+++ b/anafind/fn.go
@@ -7,8 +7,9 @@ import (
 )
 
 func Fn(words []string) map[string]map[string]struct{} {
-	nzWords := fn.ArrayOf(words).Where(MoreThanOneChar)
-	lower := fn.MapOf(nzWords, strings.ToLower)
-	singleWords := fn.MapOf(lower, SingleWordToMap)
+	wordsLower := fn.ArrayOf(words).
+		Where(MoreThanOneChar).
+		Shape(strings.ToLower)
+	singleWords := fn.MapOf(wordsLower, SingleWordToMap)
 	return fn.Into(Anagrams{}, Accumulate, singleWords)
 }

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module streams-bench
 go 1.18
 
 require (
+	github.com/kamstrup/fn v0.0.0-20221204115945-0e1323489c95
 	github.com/koss-null/lambda v0.0.0-20221113232028-328f3e65b736
 	github.com/mariomac/gostream v0.8.1
 	github.com/primetalk/goio v0.3.6

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module streams-bench
 go 1.18
 
 require (
-	github.com/kamstrup/fn v0.0.0-20221204115945-0e1323489c95
+	github.com/kamstrup/fn v0.0.0-20221204130846-c0e4aabf3128
 	github.com/koss-null/lambda v0.0.0-20221113232028-328f3e65b736
 	github.com/mariomac/gostream v0.8.1
 	github.com/primetalk/goio v0.3.6

--- a/go.sum
+++ b/go.sum
@@ -1,8 +1,8 @@
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/kamstrup/fn v0.0.0-20221204115945-0e1323489c95 h1:8Y32UnzYOgqmThhQ9E5kp0fzo03sqiVuNuYqak8MWts=
-github.com/kamstrup/fn v0.0.0-20221204115945-0e1323489c95/go.mod h1:vqT1ah2jRXZZxyRN6xMSp3QBOw4iRxSm6pGv+Jud/y8=
+github.com/kamstrup/fn v0.0.0-20221204130846-c0e4aabf3128 h1:aGX29l4+UYBc332Ovo/U8C7VpiNCWBzOToiK2825Fxg=
+github.com/kamstrup/fn v0.0.0-20221204130846-c0e4aabf3128/go.mod h1:vqT1ah2jRXZZxyRN6xMSp3QBOw4iRxSm6pGv+Jud/y8=
 github.com/koss-null/lambda v0.0.0-20221113232028-328f3e65b736 h1:DdzcFB0tQOOS6n0Mz4Q/hGTOCIh/2vbPCs6aWed5aUU=
 github.com/koss-null/lambda v0.0.0-20221113232028-328f3e65b736/go.mod h1:nTz6nv3eLfDU/TC7sQ3yNDto22rR2sRzShpP2KrfYSQ=
 github.com/mariomac/gostream v0.8.1 h1:umH0vv4LFXqMDnEhjEKr84VfIFGMhM49Oi9NOEhLZBw=

--- a/go.sum
+++ b/go.sum
@@ -1,6 +1,8 @@
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/kamstrup/fn v0.0.0-20221204115945-0e1323489c95 h1:8Y32UnzYOgqmThhQ9E5kp0fzo03sqiVuNuYqak8MWts=
+github.com/kamstrup/fn v0.0.0-20221204115945-0e1323489c95/go.mod h1:vqT1ah2jRXZZxyRN6xMSp3QBOw4iRxSm6pGv+Jud/y8=
 github.com/koss-null/lambda v0.0.0-20221113232028-328f3e65b736 h1:DdzcFB0tQOOS6n0Mz4Q/hGTOCIh/2vbPCs6aWed5aUU=
 github.com/koss-null/lambda v0.0.0-20221113232028-328f3e65b736/go.mod h1:nTz6nv3eLfDU/TC7sQ3yNDto22rR2sRzShpP2KrfYSQ=
 github.com/mariomac/gostream v0.8.1 h1:umH0vv4LFXqMDnEhjEKr84VfIFGMhM49Oi9NOEhLZBw=

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1,7 +1,7 @@
 # github.com/davecgh/go-spew v1.1.1
 ## explicit
 github.com/davecgh/go-spew/spew
-# github.com/kamstrup/fn v0.0.0-20221204115945-0e1323489c95
+# github.com/kamstrup/fn v0.0.0-20221204130846-c0e4aabf3128
 ## explicit; go 1.18
 github.com/kamstrup/fn
 # github.com/koss-null/lambda v0.0.0-20221113232028-328f3e65b736

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1,6 +1,9 @@
 # github.com/davecgh/go-spew v1.1.1
 ## explicit
 github.com/davecgh/go-spew/spew
+# github.com/kamstrup/fn v0.0.0-20221204115945-0e1323489c95
+## explicit; go 1.18
+github.com/kamstrup/fn
 # github.com/koss-null/lambda v0.0.0-20221113232028-328f3e65b736
 ## explicit; go 1.18
 github.com/koss-null/lambda/internal/algo/parallel/mergesort


### PR DESCRIPTION
Hi, great work on the benchmarks! <3 I added a benchmark with my own functional Go lib "fn".

Results:
```
$ go test ./... -bench . -benchmem -count 10 > f.txt
```
```
$ benchstat f.txt
name        time/op
Baseline-8   531µs ±37%
Mariomac-8   521µs ±29%
Lambda-8     660µs ±34%
Goio-8      1.67ms ±11%
Automi-8     772µs ±19%
Fn-8         496µs ± 7%

name        alloc/op
Baseline-8   199kB ± 0%
Mariomac-8   192kB ± 0%
Lambda-8     243kB ± 0%
Goio-8       591kB ± 0%
Automi-8     314kB ± 0%
Fn-8         192kB ± 0%

name        allocs/op
Baseline-8   2.56k ± 0%
Mariomac-8   2.57k ± 0%
Lambda-8     3.81k ± 0%
Goio-8       14.3k ± 0%
Automi-8     4.67k ± 0%
Fn-8         2.57k ± 0%
```

Memory is indentical, but I beat you by a smidgen on speed ;-P

Did a quick look through your code. Nice work! I think the primary difference between our approaches is that you seem closer to Java Streams, and I am a bit closer to Clojure. Fx. my Seq API is designed to work on "immutable sequences", ie you get a head+tail back when you walk a Seq, and the underlying Seq is stateless. Whereas your stream lib keeps a stateful iterator.